### PR TITLE
Add integration tests for tool crafting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 wasm-bindgen = "0.2"

--- a/tests/game.rs
+++ b/tests/game.rs
@@ -1,0 +1,35 @@
+use incremental_rust_game::Game;
+
+#[test]
+fn craft_axe_only_once_integration() {
+    let mut game = Game::new();
+    for _ in 0..10 { game.collect_wood(); }
+    for _ in 0..5 { game.collect_stone(); }
+
+    // First crafting should succeed
+    assert!(game.craft_axe());
+    assert_eq!(game.get_wood(), 0);
+    assert_eq!(game.get_stone(), 0);
+
+    // Second crafting should fail and not change resources
+    assert!(!game.craft_axe());
+    assert_eq!(game.get_wood(), 0);
+    assert_eq!(game.get_stone(), 0);
+}
+
+#[test]
+fn craft_pickaxe_only_once_integration() {
+    let mut game = Game::new();
+    for _ in 0..5 { game.collect_wood(); }
+    for _ in 0..10 { game.collect_stone(); }
+
+    // First crafting should succeed
+    assert!(game.craft_pickaxe());
+    assert_eq!(game.get_wood(), 0);
+    assert_eq!(game.get_stone(), 0);
+
+    // Second crafting should fail and not change resources
+    assert!(!game.craft_pickaxe());
+    assert_eq!(game.get_wood(), 0);
+    assert_eq!(game.get_stone(), 0);
+}


### PR DESCRIPTION
## Summary
- add integration tests verifying tool crafting in `tests/game.rs`
- produce `rlib` for integration tests by updating `Cargo.toml`

## Testing
- `cargo test -q`

------
https://chatgpt.com/codex/tasks/task_e_6841600438d883249d52e3bb924df99b