### PR TITLE
Update README prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ cargo install wasm-bindgen-cli
 Make sure you have installed:
 - Rust
 - Python
+- wasm-bindgen-cli
 
 `cd` to root of the repo and run in terminal:
 ```


### PR DESCRIPTION
## Summary
- document that `wasm-bindgen-cli` is required before running the game

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6841600e94f483248a36aa06a60ad665