### PR TITLE
Fix README capitalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Make sure you have installed:
 .\BUILD.bat
 ```
 
-Open this url in any browser:
+Open this URL in any browser:
 ```
 http://localhost:8000/
 ```


### PR DESCRIPTION
## Summary
- fix capitalization in setup instructions

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6841601839248324ab59334cfe82ff43