### PR TITLE
Add auto-merge workflow

### DIFF
--- a/.github/workflows/auto-merge-codex.yml
+++ b/.github/workflows/auto-merge-codex.yml
@@ -1,0 +1,21 @@
+name: Auto Merge Codex PRs
+
+on:
+  pull_request_target:
+    # Run when codex-labeled pull requests are opened, updated,
+    # marked ready for review, or labeled
+    types: [opened, ready_for_review, synchronize, labeled]
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  automerge:
+    # The PRs are opened by SirLovi but automatically labeled "codex"
+    if: contains(github.event.pull_request.labels.*.name, 'codex')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: peter-evans/enable-pull-request-automerge@v3
+        with:
+          merge-method: squash


### PR DESCRIPTION
## Summary
- add Github Action to enable auto-merge for Codex pull requests
- update workflow to detect the 'codex' label instead of PR author

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6841643a56b483248957648dfe55ac72