### PR TITLE
Prevent negative resources in tick

### DIFF
--- a/src/resources.rs
+++ b/src/resources.rs
@@ -25,6 +25,25 @@ impl Resources {
         self.gold += other.gold;
     }
 
+    /// Ensure all resources are non-negative
+    pub fn clamp_non_negative(&mut self) {
+        if self.wood < 0.0 {
+            self.wood = 0.0;
+        }
+        if self.stone < 0.0 {
+            self.stone = 0.0;
+        }
+        if self.food < 0.0 {
+            self.food = 0.0;
+        }
+        if self.iron < 0.0 {
+            self.iron = 0.0;
+        }
+        if self.gold < 0.0 {
+            self.gold = 0.0;
+        }
+    }
+
     /// Subtract other resources if affordable
     pub fn subtract(&mut self, cost: &Resources) -> bool {
         if self.can_afford(cost) {

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -64,6 +64,7 @@ impl GameState {
             for _ in 0..ticks {
                 let y = self.tick_yield();
                 self.resources.add(&y);
+                self.resources.clamp_non_negative();
             }
             self.last_update = Some(prev + ticks as f64 * self.tick_rate);
         } else {
@@ -140,5 +141,18 @@ mod tests {
         g.tick(10.0);
         g.tick(20.0);
         assert_eq!(g.resources.food, start + 10.0);
+    }
+
+    #[test]
+    fn bakery_food_depletion() {
+        let mut g = GameState::new();
+        g.resources = res(100.0, 100.0, 100.5, 100.0, 100.0);
+        g.research.unlock(Tech::Baking);
+        assert!(g.build("bakery".into()));
+        g.resources.food = 0.5;
+        g.tick(0.0);
+        g.tick(1.0);
+        assert_eq!(g.resources.food, 0.0);
+        assert!((g.resources.gold - 100.2).abs() < 1e-6);
     }
 }


### PR DESCRIPTION
## Summary
- ensure resources never go negative by clamping after each tick
- add convenience `clamp_non_negative` function
- test bakery behavior when it runs out of food

## Testing
- `cargo test --lib`
- `cargo test --tests`


------
https://chatgpt.com/codex/tasks/task_e_6849d23747008324a2d92092bfbddbdd