### PR TITLE
Restrict BuildingInfo visibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,4 +17,4 @@ jobs:
           node-version: 18
       - run: npm install -g wasm-pack
       - name: Wasm tests
-        run: wasm-pack test --headless
+        run: wasm-pack test --node

--- a/src/buildings.rs
+++ b/src/buildings.rs
@@ -18,7 +18,7 @@ pub enum BuildingType {
 }
 
 /// Static data for a building
-pub struct BuildingInfo {
+pub(crate) struct BuildingInfo {
     pub base_cost: Resources,
     pub growth: f64,
     pub yield_per_tick: Resources,


### PR DESCRIPTION
## Summary
- mark `BuildingInfo` as `pub(crate)` since it isn't used externally
- fix CI wasm test command to use `--node`

## Testing
- `cargo test --all --quiet`
- `wasm-pack test --node` *(fails: failed to download component)*

------
https://chatgpt.com/codex/tasks/task_e_6849d2da52588324bbc8b818a48cbe5b