### PR TITLE
Add building cost query and button update

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,14 @@ impl Game {
         GAME.with(|g| g.borrow().get_resource(name.into()))
     }
 
+    /// Get the cost of constructing the next level of a building as a JSON string
+    pub fn building_cost(name: &str) -> String {
+        GAME.with(|g| {
+            let cost = g.borrow().build_cost(name.into());
+            serde_json::to_string(&cost).expect("serialize cost")
+        })
+    }
+
     /// Save game to a base64 string
     pub fn save() -> String {
         GAME.with(|g| g.borrow().save_string())

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -92,6 +92,19 @@ impl GameState {
         self.buildings.build(ty, &mut self.resources)
     }
 
+    /// Get the current cost to build the next level of a building by name
+    pub fn build_cost(&self, name: String) -> Resources {
+        let ty = match name.as_str() {
+            "farm" => BuildingType::Farm,
+            "lumber_mill" => BuildingType::LumberMill,
+            "quarry" => BuildingType::Quarry,
+            "mine" => BuildingType::Mine,
+            "bakery" => BuildingType::Bakery,
+            _ => return Resources::default(),
+        };
+        self.buildings.cost(ty)
+    }
+
     /// Get resource by name
     pub fn get_resource(&self, name: String) -> f64 {
         match name.as_str() {

--- a/ui/main.js
+++ b/ui/main.js
@@ -7,6 +7,18 @@ const logDiv = document.getElementById('log');
 
 const resourceNames = ['wood', 'stone', 'food', 'iron', 'gold'];
 const buildingNames = ['farm', 'lumber_mill', 'quarry', 'mine', 'bakery'];
+const buildingButtons = {};
+
+function formatCost(cost) {
+    const parts = [];
+    for (const r of resourceNames) {
+        const v = cost[r];
+        if (v > 0) {
+            parts.push(`${v.toFixed(1)} ${r}`);
+        }
+    }
+    return parts.join(', ');
+}
 
 function log(msg) {
     const p = document.createElement('p');
@@ -22,12 +34,28 @@ function updateResources() {
         span.textContent = `${name}: ${game.get_resource(name).toFixed(1)}`;
         resourcesDiv.appendChild(span);
     }
+
+    for (const name of buildingNames) {
+        const cost = JSON.parse(game.building_cost(name));
+        const btn = buildingButtons[name];
+        if (!btn) continue;
+        btn.textContent = `Build ${name} (${formatCost(cost)})`;
+        let affordable = true;
+        for (const r of resourceNames) {
+            if (game.get_resource(r) < cost[r]) {
+                affordable = false;
+                break;
+            }
+        }
+        btn.disabled = !affordable;
+    }
 }
 
 function buildButtons() {
     buildingsDiv.innerHTML = '';
     for (const name of buildingNames) {
         const btn = document.createElement('button');
+        buildingButtons[name] = btn;
         btn.textContent = `Build ${name}`;
         btn.className = 'btn';
         btn.onclick = () => {


### PR DESCRIPTION
## Summary
- expose `Game::building_cost` for the next building level cost
- implement `GameState::build_cost` helper
- display cost on building buttons and disable them when unaffordable

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6849d74c578c8324bfc7368ebf7f9c7f