### PR TITLE
Enable wasm-bindgen tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,4 +21,9 @@ futures = "0.3"
 js-sys = "0.3"
 rand = "0.8"
 
+[target.'cfg(target_arch = "wasm32")'.dependencies.getrandom]
+version = "0.2"
+features = ["js"]
+
 [dev-dependencies]
+wasm-bindgen-test = "0.3"

--- a/src/events.rs
+++ b/src/events.rs
@@ -39,8 +39,9 @@ mod tests {
     use super::*;
     use rand::SeedableRng;
     use rand::rngs::StdRng;
+    use wasm_bindgen_test::wasm_bindgen_test;
 
-    #[test]
+    #[wasm_bindgen_test]
     fn farm_loss_triggers() {
         let mut b = Buildings::default();
         for _ in 0..10 {

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -171,8 +171,9 @@ impl GameState {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use wasm_bindgen_test::wasm_bindgen_test;
 
-    #[test]
+    #[wasm_bindgen_test]
     fn cost_curve() {
         let c0 = Buildings::cost_for_level(BuildingType::Farm, 0).wood;
         let c1 = Buildings::cost_for_level(BuildingType::Farm, 1).wood;
@@ -180,7 +181,7 @@ mod tests {
         assert!((c1 - c0 * 1.15).abs() < 1e-6);
     }
 
-    #[test]
+    #[wasm_bindgen_test]
     fn offline_progress() {
         let mut g = GameState::new();
         g.event_chance = 0.0;
@@ -192,7 +193,7 @@ mod tests {
         assert_eq!(g.resources.food, start + 10.0);
     }
 
-    #[test]
+    #[wasm_bindgen_test]
     fn bakery_food_depletion() {
         let mut g = GameState::new();
         g.event_chance = 0.0;

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,7 +1,8 @@
 use incremental_rust_game::{GameState, res, farm_loss_event, BuildingType};
 use rand::{rngs::StdRng, SeedableRng};
+use wasm_bindgen_test::wasm_bindgen_test;
 
-#[test]
+#[wasm_bindgen_test]
 fn ten_minutes_growth() {
     let mut g = GameState::new();
     g.event_chance = 0.0;
@@ -13,7 +14,7 @@ fn ten_minutes_growth() {
     assert_eq!(g.resources.food, start + 600.0);
 }
 
-#[test]
+#[wasm_bindgen_test]
 fn event_triggers() {
     let mut g = GameState::new();
     g.resources = res(0.0, 0.0, 0.0, 0.0, 0.0);


### PR DESCRIPTION
## Summary
- add `wasm-bindgen-test` as a dev dependency and configure `getrandom` for wasm32
- convert tests to use `#[wasm_bindgen_test]`

## Testing
- `cargo test`
- `wasm-pack test --node`


------
https://chatgpt.com/codex/tasks/task_e_6849ddc100f88324bd88f53345abef06