### PR TITLE
Fix wasm CI build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,8 @@ jobs:
         with:
           toolchain: stable
           override: true
+      - name: Install WebAssembly target
+        run: rustup target add wasm32-unknown-unknown
       - name: Cargo test
         run: cargo test --all
       - uses: actions/setup-node@v3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,10 +20,8 @@ base64 = "0.21"
 futures = "0.3"
 js-sys = "0.3"
 rand = "0.8"
+getrandom = { version = "0.2.16", features = ["js"] }
 
-[target.'cfg(target_arch = "wasm32")'.dependencies.getrandom]
-version = "0.2"
-features = ["js"]
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3"


### PR DESCRIPTION
## Summary
- enable `getrandom` `js` feature so wasm builds succeed
- install wasm target in CI workflow before tests

## Testing
- `cargo test --all`
- `wasm-pack test --node`


------
https://chatgpt.com/codex/tasks/task_e_6849e1eea6a48324b3c24a2183dbdb17